### PR TITLE
Fix initdb error by specifying PGDATA

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       POSTGRES_DB: brm-database
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin
+      PGDATA: /var/lib/postgresql/data/pgdata
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
# What has been changed?
In this PR, the configuration of the PostgreSQL container has been updated to include the PGDATA environment variable. Previously, the database was configured with the default data directory, which caused issues when the directory was not empty. Now, a custom data directory (/var/lib/postgresql/data/pgdata) has been specified to avoid conflicts with other files in the volume.

# How
To achieve this update, the docker-compose.yml file was modified. The PGDATA environment variable with the value /var/lib/postgresql/data/pgdata was added in the configuration section of the PostgreSQL service.