### PR TITLE
feat: run expres with yarn

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,12 @@ services:
       POSTGRES_PASSWORD: admin
       POSTGRES_HOST: postgres-db
       DIALECT: postgres
-    command: tail -f /dev/null
+    command:
+      - /bin/sh
+      - -c
+      - |
+        yarn install
+        yarn run start
     depends_on:
       - db
 


### PR DESCRIPTION
# What? 

Changes in the docker-compose.yml file:

Previously, the Docker container defined in the docker-compose.yml file was running with the command tail -f /dev/null. We have made an update so that now, after building the image using docker-compose build, when creating the containers with `docker-compose up -d`, the backend server will automatically start and connect to the database.

Furthermore, we have added an additional container for PgAdmin, which provides a user-friendly graphical interface for efficiently managing database tables.